### PR TITLE
add more packages to test environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         architecture: 'x64'
     - name: Install the library
       run: |
-        pip install nbdev jupyter
+        pip install nbdev jupyter xarray dask scipy
         pip install -e .
     - name: Read all notebooks
       run: |


### PR DESCRIPTION
There are lots of ways to do this. Eventually you will want to declare your package's dependencies somewhere, e.g. setup.py. For now, putting them into the environment should solve the CI issue.