### PR TITLE
Update Gemfile.lock

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       liquid (= 4.0.3)
       mercenary (~> 0.3)
       minima (= 2.5.1)
-      nokogiri (>= 1.10.4, < 2.0)
+      nokogiri (>= 1.11.0, < 2.0)
       rouge (= 3.19.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)
@@ -208,7 +208,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.1)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (>= 1.11.0)
       mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
@@ -255,7 +255,7 @@ DEPENDENCIES
   github-pages
   jekyll (>= 3.7)
   kramdown (>= 2.3.0)
-  nokogiri (< 1.10.9)
+  nokogiri (>= 1.11.0)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
resolves security issues with nokogiri. Remediation was to upgrade nokogiri to version 1.11.0.rc4 or later.